### PR TITLE
Fix Gmail OAuth prompt and address encoding

### DIFF
--- a/modules/Core/app/Common/OAuth/OAuthManager.php
+++ b/modules/Core/app/Common/OAuth/OAuthManager.php
@@ -126,6 +126,7 @@ class OAuthManager
             'clientSecret' => config('integrations.google.client_secret'),
             'redirectUri' => $redirectUrl ?: url(config('integrations.google.redirect_uri')),
             'accessType' => config('integrations.google.access_type'),
+            'prompt' => config('integrations.google.prompt'),
             'scopes' => config('integrations.google.scopes'),
         ]);
     }

--- a/modules/Core/config/integrations.php
+++ b/modules/Core/config/integrations.php
@@ -119,6 +119,11 @@ return [
         'access_type' => 'offline',
 
         /**
+         * OAuth consent prompt
+         */
+        'prompt' => 'consent',
+
+        /**
          * Scopes for OAuth
          */
         'scopes' => ['https://mail.google.com/', 'https://www.googleapis.com/auth/calendar'],

--- a/modules/MailClient/app/Services/EmailAccountMessageSyncService.php
+++ b/modules/MailClient/app/Services/EmailAccountMessageSyncService.php
@@ -255,7 +255,7 @@ class EmailAccountMessageSyncService
                 if (! mb_check_encoding($address['name'], 'UTF-8')) {
                     $address['name'] = mb_convert_encoding($address['name'], 'UTF-8', 'ISO-8859-1');
                 }
-                $address['name'] = preg_replace('/[^\x20-\x7E\xA0-\xFF]/', '', $address['name']); // Remove invalid characters
+                $address['name'] = preg_replace('/[^\x20-\x7E\xA0-\xFF]/u', '', $address['name']); // Remove invalid characters
             }
 
             $message->addresses()->create(array_merge($address, [


### PR DESCRIPTION
## Summary
- configure Gmail OAuth to request consent prompt
- add `prompt` option when creating Google provider
- handle invalid characters in address names when syncing emails

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68473c3ece00832889dc47d655cbdbf8